### PR TITLE
First-Class Block Entity Components (fix #40)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ allprojects {
         modApi "net.fabricmc:fabric-loader:${rootProject.loader_version}"
         modApi fabricApi.module("fabric-api-base", rootProject.fabric_api_version)
         modImplementation fabricApi.module("fabric-networking-v0", rootProject.fabric_api_version)
+        modImplementation fabricApi.module("fabric-networking-blockentity-v0", rootProject.fabric_api_version)
         testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.0-M1"
         testImplementation "org.junit.jupiter:junit-jupiter-params:5.5.0-M1"
         compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/cardinal-components-base/src/main/java/nerdhub/cardinal/components/api/component/ComponentProvider.java
+++ b/cardinal-components-base/src/main/java/nerdhub/cardinal/components/api/component/ComponentProvider.java
@@ -24,6 +24,8 @@ package nerdhub.cardinal.components.api.component;
 
 import dev.onyxstudios.cca.api.v3.component.ComponentContainer;
 import nerdhub.cardinal.components.api.ComponentType;
+
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.scoreboard.AbstractTeam;
@@ -50,6 +52,14 @@ public interface ComponentProvider extends dev.onyxstudios.cca.api.v3.component.
     @SuppressWarnings("ConstantConditions")
     static ComponentProvider fromItemStack(ItemStack stack) {
         return (ComponentProvider) (Object) stack;
+    }
+
+    /**
+     * Convenience method to retrieve a ComponentProvider from a given {@link BlockEntity}.
+     * Requires the <tt>cardinal-components-block</tt> module.
+     */
+    static ComponentProvider fromBlockEntity(BlockEntity blockEntity) {
+        return (ComponentProvider) blockEntity;
     }
 
     /**

--- a/cardinal-components-block/src/main/java/dev/onyxstudios/cca/CardinalComponentsBlock.java
+++ b/cardinal-components-block/src/main/java/dev/onyxstudios/cca/CardinalComponentsBlock.java
@@ -1,0 +1,67 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019-2020 OnyxStudios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package dev.onyxstudios.cca;
+
+import dev.onyxstudios.cca.api.component.v3.util.BlockEntitySyncedComponent;
+import dev.onyxstudios.cca.internal.base.ComponentsInternals;
+import nerdhub.cardinal.components.api.ComponentRegistry;
+import nerdhub.cardinal.components.api.ComponentType;
+import nerdhub.cardinal.components.api.component.extension.SyncedComponent;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+
+import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+import net.fabricmc.loader.api.FabricLoader;
+
+public class CardinalComponentsBlock {
+    // Safe to put in the same class as no client-only class is directly referenced
+    public static void initClient() {
+        if (FabricLoader.getInstance().isModLoaded("fabric-networking-v0")) {
+            ClientSidePacketRegistry.INSTANCE.register(BlockEntitySyncedComponent.PACKET_ID, (context, buffer) -> {
+                try {
+                    BlockPos position = buffer.readBlockPos();
+                    Identifier componentTypeId = buffer.readIdentifier();
+                    ComponentType<?> componentType = ComponentRegistry.INSTANCE.get(componentTypeId);
+                    if (componentType == null) {
+                        return;
+                    }
+                    PacketByteBuf copy = new PacketByteBuf(buffer.copy());
+                    context.getTaskQueue().execute(() -> {
+                        try {
+                            componentType.maybeGet(context.getPlayer().world.getBlockEntity(position))
+                                .filter(c -> c instanceof SyncedComponent)
+                                .ifPresent(c -> ((SyncedComponent) c).processPacket(context, copy));
+                        } finally {
+                            copy.release();
+                        }
+                    });
+                } catch (Exception e) {
+                    ComponentsInternals.LOGGER.error("Error while reading block entity components from network", e);
+                    throw e;
+                }
+            });
+        }
+    }
+}

--- a/cardinal-components-block/src/main/java/dev/onyxstudios/cca/api/component/v3/block/entity/BlockEntityComponentFactory.java
+++ b/cardinal-components-block/src/main/java/dev/onyxstudios/cca/api/component/v3/block/entity/BlockEntityComponentFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019-2020 OnyxStudios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package dev.onyxstudios.cca.api.component.v3.block.entity;
+
+import javax.annotation.Nonnull;
+
+import nerdhub.cardinal.components.api.component.Component;
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.block.entity.BlockEntity;
+
+/**
+ * A component factory for {@linkplain BlockEntity block entities}.
+ *
+ * <p>When invoked, the factory must return a {@link Component} of the right type.
+ *
+ * @since 2.4.0 TODO: fix before releasing! this did not come out in 2.4.0!
+ */
+@ApiStatus.Experimental
+@FunctionalInterface
+public interface BlockEntityComponentFactory<C extends Component, E extends BlockEntity> {
+    /**
+     * Create a component of type {@code C} for the given entity.
+     *
+     * <p>The component returned by this method will be available
+     * on the entity as soon as all component factories have been invoked.
+     *
+     * <p><strong>The {@code blockEntity} may not be fully initialized when this method is called!</strong>
+     * Implementations should resort to lazy initialization if they need properties not available in the
+     * base {@link BlockEntity} class.
+     *
+     * @param blockEntity     the block entity being constructed
+     * @implNote Because this method is called for each block entity creation, implementations
+     * should avoid side effects and keep costly computations at a minimum. Lazy initialization
+     * should be considered for components that are costly to initialize.
+     */
+    @Nonnull
+    C createForEntity(E blockEntity);
+}

--- a/cardinal-components-block/src/main/java/dev/onyxstudios/cca/api/component/v3/block/entity/BlockEntityComponentFactoryRegistry.java
+++ b/cardinal-components-block/src/main/java/dev/onyxstudios/cca/api/component/v3/block/entity/BlockEntityComponentFactoryRegistry.java
@@ -1,0 +1,54 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019-2020 OnyxStudios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package dev.onyxstudios.cca.api.component.v3.block.entity;
+
+import dev.onyxstudios.cca.api.v3.component.ComponentKey;
+import nerdhub.cardinal.components.api.component.Component;
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.block.entity.BlockEntity;
+
+/**
+ * @since 2.4.0 TODO: fix before releasing! this did not come out in 2.4.0!
+ */
+@ApiStatus.Experimental
+public interface BlockEntityComponentFactoryRegistry {
+
+    /**
+     * Registers an {@link BlockEntityComponentFactory} for all instances of a given entity class.
+     *
+     * <p> Callers of this method should always use the most specific entity
+     * type for their use. For example, a factory which goal is to attach a component
+     * to players should pass {@code PlayerEntity.class} as a parameter,
+     * not one of its superclasses. This limits the need for entity-dependant
+     * checks, as well as the amount of redundant callback invocations.
+     * For these same reasons, when registering factories for various entity types,
+     * it is often better to register a separate specialized callback for each type
+     * than a single generic callback with additional checks.
+     *
+     * @param target  a class object representing the type of entities targeted by the factory
+     * @param factory the factory to use to create components of the given type
+     */
+    <C extends Component, E extends BlockEntity> void registerFor(Class<E> target, ComponentKey<C> type, BlockEntityComponentFactory<C, E> factory);
+
+}

--- a/cardinal-components-block/src/main/java/dev/onyxstudios/cca/api/component/v3/block/entity/BlockEntityComponentInitializer.java
+++ b/cardinal-components-block/src/main/java/dev/onyxstudios/cca/api/component/v3/block/entity/BlockEntityComponentInitializer.java
@@ -1,0 +1,48 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019-2020 OnyxStudios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package dev.onyxstudios.cca.api.component.v3.block.entity;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.block.entity.BlockEntity;
+
+/**
+ * Entrypoint getting invoked to register <em>static</em> entity component factories.
+ *
+ * <p>The entrypoint is exposed as {@code cardinal-components-entity} in the mod json and runs for any environment.
+ * It usually executes right before the first {@link BlockEntity} instance is created.
+ *
+ * @since 2.4.0 TODO: fix before releasing! this did not come out in 2.4.0!
+ */
+@ApiStatus.Experimental
+public interface BlockEntityComponentInitializer {
+    /**
+     * Called to register component factories for statically declared component types.
+     *
+     * <p><strong>The passed registry must not be held onto!</strong> Static component factories
+     * must not be registered outside of this method.
+     *
+     * @param registry an {@link BlockEntityComponentFactoryRegistry} for <em>statically declared</em> components
+     */
+    void registerBlockEntityComponentFactories(BlockEntityComponentFactoryRegistry registry);
+}

--- a/cardinal-components-block/src/main/java/dev/onyxstudios/cca/api/component/v3/event/BlockEntityComponentCallback.java
+++ b/cardinal-components-block/src/main/java/dev/onyxstudios/cca/api/component/v3/event/BlockEntityComponentCallback.java
@@ -1,0 +1,104 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019-2020 OnyxStudios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package dev.onyxstudios.cca.api.component.v3.event;
+
+import dev.onyxstudios.cca.api.component.v3.block.entity.BlockEntityComponentFactory;
+import dev.onyxstudios.cca.internal.block.CardinalBlockInternals;
+import nerdhub.cardinal.components.api.ComponentType;
+import nerdhub.cardinal.components.api.component.Component;
+import nerdhub.cardinal.components.api.component.ComponentContainer;
+import nerdhub.cardinal.components.api.event.ComponentCallback;
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.block.entity.BlockEntity;
+
+import net.fabricmc.fabric.api.event.Event;
+
+
+/**
+ * The callback interface for receiving component initialization events
+ * during block entity construction.
+ *
+ * <p> The element that is interested in attaching components
+ * to entities implements this interface, and is
+ * registered with a class' event, using {@link Event#register(Object)}.
+ * When an entity of an applicable type is constructed, the callback's
+ * {@link #initComponents} method is invoked.
+ *
+ * <p> Block entity component callbacks are registered per BE class, and apply to
+ * instances of that class and of every subclass. More formally, if a callback
+ * is registered for a class {@code E}, its {@code initComponents} method will
+ * be invoked for any block entity {@code e} verifying {@code e instanceof E}.
+ *
+ * @param <E> the type of block entity targeted by this callback
+ */
+@FunctionalInterface
+public interface BlockEntityComponentCallback<E extends BlockEntity> extends ComponentCallback<E, Component> {
+
+    /**
+     * Returns the {@code Event} used to register component callbacks for
+     * entities of the given type.
+     *
+     * <p> Callers of this method should always use the most specific entity
+     * type for their use. For example, a callback which goal is to attach a component
+     * to players should pass {@code PlayerEntity.class} as a parameter,
+     * not one of its superclasses. This limits the need for entity-dependant
+     * checks, as well as the amount of redundant callback invocations.
+     * For these reasons, when registering callbacks for various entity types,
+     * it is often better to register a separate specialized callback for each type
+     * than a single generic callback with additional checks.
+     *
+     * @param clazz The class object representing the desired entity type
+     * @param <E>   The type of entities targeted by the event
+     * @return the {@code Event} used to register component callbacks for entities
+     * of the given type.
+     * @throws IllegalArgumentException if {@code clazz} is not an entity class
+     */
+    static <E extends BlockEntity> Event<BlockEntityComponentCallback<E>> event(Class<E> clazz) {
+        return CardinalBlockInternals.event(clazz);
+    }
+
+    @ApiStatus.Experimental
+    static <C extends Component, E extends BlockEntity> void register(ComponentType<C> type, Class<E> targetClass, BlockEntityComponentFactory<C, E> factory) {
+        event(targetClass).register((entity, components) -> components.put(type, factory.createForEntity(entity)));
+    }
+
+    /**
+     * Initialize components for the given block entity.
+     *
+     * <p>Components that are added to the given container will be available
+     * on the block entity as soon as all callbacks have been invoked.
+     *
+     * <p><strong>The {@code blockEntity} may not be fully initialized when this method is called!</strong>
+     * Implementations should resort to lazy initialization if they need properties not available in the
+     * base {@link BlockEntity} class.
+     *
+     * @param blockEntity the block entity being constructed
+     * @param components the block entity's component container
+     * @implNote Because this method is called for each entity creation, implementations
+     * should avoid side effects and keep costly computations at a minimum. Lazy initialization
+     * should be considered for components that are costly to initialize.
+     */
+    @Override
+    void initComponents(E blockEntity, ComponentContainer<Component> components);
+}

--- a/cardinal-components-block/src/main/java/dev/onyxstudios/cca/api/component/v3/util/BlockEntitySyncedComponent.java
+++ b/cardinal-components-block/src/main/java/dev/onyxstudios/cca/api/component/v3/util/BlockEntitySyncedComponent.java
@@ -1,0 +1,105 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019-2020 OnyxStudios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package dev.onyxstudios.cca.api.component.v3.util;
+
+import io.netty.buffer.Unpooled;
+import nerdhub.cardinal.components.api.ComponentType;
+import nerdhub.cardinal.components.api.component.ComponentProvider;
+import nerdhub.cardinal.components.api.component.extension.SyncedComponent;
+import nerdhub.cardinal.components.api.component.extension.TypeAwareComponent;
+import nerdhub.cardinal.components.api.util.sync.BaseSyncedComponent;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.fabric.api.block.entity.BlockEntityClientSerializable;
+import net.fabricmc.fabric.api.network.PacketContext;
+import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
+import net.fabricmc.fabric.api.server.PlayerStream;
+
+/**
+ * Default implementations of {@link SyncedComponent} methods, specialized for block entity components
+ */
+public interface BlockEntitySyncedComponent extends BaseSyncedComponent {
+    /**
+     * {@link CustomPayloadS2CPacket} channel for default block entity component synchronization.
+     *
+     * <p> Packets emitted on this channel must begin with, in order, the {@link BlockEntity#getPos()} block entity position},
+     * and the {@link ComponentType#getId() component's type} (as an Identifier).
+     *
+     * <p> Components synchronized through this channel will have {@linkplain SyncedComponent#processPacket(PacketContext, PacketByteBuf)}
+     * called on the game thread.
+     */
+    Identifier PACKET_ID = new Identifier("cardinal-components", "block_entity_sync");
+
+    BlockEntity getBlockEntity();
+
+    /**
+     * {@inheritDoc}
+     * @implNote The default implementation should generally be overridden.
+     * This implementation performs a linear-time lookup on the provider to find the component type
+     * this component is associated with.
+     * Implementing classes can nearly always provide a better implementation.
+     */
+    @Override
+    default ComponentType<?> getComponentType() {
+        return TypeAwareComponent.lookupComponentType(ComponentProvider.fromBlockEntity(this.getBlockEntity()), this);
+    }
+
+    @Override
+    default void sync() {
+        if (!this.getBlockEntity().getWorld().isClient) {
+            BlockEntity holder = this.getBlockEntity();
+            if (holder instanceof BlockEntityClientSerializable) {
+                ((BlockEntityClientSerializable) holder).sync();
+            } else {
+                holder.markDirty();
+            }
+            PlayerStream.watching(holder).map(ServerPlayerEntity.class::cast).forEach(this::syncWith);
+        }
+    }
+
+    @Override
+    default void syncWith(ServerPlayerEntity player) {
+        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+        buf.writeBlockPos(this.getBlockEntity().getPos());
+        buf.writeIdentifier(this.getComponentType().getId());
+        this.writeToPacket(buf);
+        ServerSidePacketRegistry.INSTANCE.sendToPlayer(player, PACKET_ID, buf);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see #PACKET_ID
+     */
+    @Override
+    default void processPacket(PacketContext ctx, PacketByteBuf buf) {
+        assert ctx.getTaskQueue().isOnThread();
+        this.readFromPacket(buf);
+    }
+}
+

--- a/cardinal-components-block/src/main/java/dev/onyxstudios/cca/internal/block/CardinalBlockInternals.java
+++ b/cardinal-components-block/src/main/java/dev/onyxstudios/cca/internal/block/CardinalBlockInternals.java
@@ -1,0 +1,121 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019-2020 OnyxStudios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package dev.onyxstudios.cca.internal.block;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import dev.onyxstudios.cca.api.component.v3.event.BlockEntityComponentCallback;
+import dev.onyxstudios.cca.api.v3.component.ComponentContainer;
+import dev.onyxstudios.cca.internal.base.ComponentsInternals;
+import dev.onyxstudios.cca.internal.base.DynamicContainerFactory;
+import nerdhub.cardinal.components.api.component.BlockComponentProvider;
+import nerdhub.cardinal.components.api.component.Component;
+import nerdhub.cardinal.components.api.component.extension.CopyableComponent;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntity;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+public class CardinalBlockInternals {
+
+    private CardinalBlockInternals() { throw new AssertionError(); }
+
+    private static final Map<Class<? extends BlockEntity>, Event<?>> BLOCK_ENTITY_EVENTS = Collections.synchronizedMap(new HashMap<>());
+    private static final Map<Class<? extends BlockEntity>, DynamicContainerFactory<BlockEntity, Component>> blockEntityContainerFactories = new HashMap<>();
+    private static final Object factoryMutex = new Object();
+    private static final Map<Block, CompoundBlockComponentProvider> INJECTIONS = new HashMap<>();
+
+    @SuppressWarnings("unchecked")
+    public static <T extends BlockEntity> Event<BlockEntityComponentCallback<T>> event(Class<T> clazz) {
+        Preconditions.checkArgument(BlockEntity.class.isAssignableFrom(clazz), "Entity component events must be registered on entity classes.");
+        // This cast keeps the gates of hell shut. This cast keeps the darkness within. This cast ensures the feeble
+        // light of the compiler never goes out, for what comes after is only death and destruction.
+        // You who sees this code, turn back before it is too late. For no one must witness the horror sealed within.
+        // DO NOT REMOVE THIS CAST (https://gist.github.com/Pyrofab/10892e2256ed181855b0809670cfdbbb)
+        //noinspection RedundantCast
+        return (Event<BlockEntityComponentCallback<T>>) BLOCK_ENTITY_EVENTS.computeIfAbsent(clazz, c ->
+            EventFactory.createArrayBacked(BlockEntityComponentCallback.class, callbacks -> (BlockEntityComponentCallback<BlockEntity>) (entity, components) -> {
+                for (BlockEntityComponentCallback<BlockEntity> callback : callbacks) {
+                    callback.initComponents(entity, components);
+                }
+            })
+        );
+    }
+
+    /**
+     * Gets a container factory for an entity class, or creates one if none exists.
+     * The container factory will populate the container by invoking events for that class
+     * and every superclass, in order from least specific (Entity) to most specific ({@code clazz}).
+     */
+    @SuppressWarnings("unchecked")
+    public static ComponentContainer<?> createEntityComponentContainer(BlockEntity entity) {
+        Class<? extends BlockEntity> entityClass = entity.getClass();
+        DynamicContainerFactory<BlockEntity, Component> existing = blockEntityContainerFactories.get(entityClass);
+        if (existing != null) {
+            return existing.create(entity);
+        }
+        synchronized (factoryMutex) {
+            // computeIfAbsent and not put, because the factory may have been generated while waiting
+            return blockEntityContainerFactories.computeIfAbsent(entityClass, cl -> {
+                List<Event<?>> events = new ArrayList<>();
+                Class<? extends BlockEntity> c = cl;
+                Class<? extends BlockEntity> parentWithStaticComponents = null;
+
+                while (BlockEntity.class.isAssignableFrom(c)) {
+                    events.add(BlockEntityComponentCallback.event(c));
+                    if (parentWithStaticComponents == null && StaticBlockEntityComponentPlugin.INSTANCE.requiresStaticFactory(c)) {   // try to find a specialized ASM factory
+                        parentWithStaticComponents = c;
+                    }
+                    c = (Class<? extends BlockEntity>) c.getSuperclass();
+                }
+                assert parentWithStaticComponents != null;
+                Class<? extends DynamicContainerFactory<BlockEntity,Component>> factoryClass = (Class<? extends DynamicContainerFactory<BlockEntity, Component>>) StaticBlockEntityComponentPlugin.INSTANCE.spinDedicatedFactory(new StaticBlockEntityComponentPlugin.Key(events.size(), parentWithStaticComponents));
+
+                return ComponentsInternals.createFactory(factoryClass, Lists.reverse(events).toArray(new Event[0]));
+            }).create(entity);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <C extends Component> void copyAsCopyable(Component from, CopyableComponent<C> to) {
+        to.copyFrom((C) from);
+    }
+
+    public static BlockComponentProvider getProvider(Block block) {
+        if (INJECTIONS.containsKey(block)) return INJECTIONS.get(block);
+        return (BlockComponentProvider) block;
+    }
+
+    public static void addSecondaryProvider(Block block, BlockComponentProvider provider) {
+        CompoundBlockComponentProvider compound = INJECTIONS.computeIfAbsent(block, bl -> new CompoundBlockComponentProvider((BlockComponentProvider) block));
+        compound.addSecondary(provider);
+    }
+}

--- a/cardinal-components-block/src/main/java/dev/onyxstudios/cca/internal/block/CompoundBlockComponentProvider.java
+++ b/cardinal-components-block/src/main/java/dev/onyxstudios/cca/internal/block/CompoundBlockComponentProvider.java
@@ -1,0 +1,82 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019-2020 OnyxStudios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package dev.onyxstudios.cca.internal.block;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import nerdhub.cardinal.components.api.ComponentType;
+import nerdhub.cardinal.components.api.component.BlockComponentProvider;
+import nerdhub.cardinal.components.api.component.Component;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.BlockView;
+
+public class CompoundBlockComponentProvider implements BlockComponentProvider {
+    private final BlockComponentProvider primary;
+    private final List<BlockComponentProvider> secondary;
+
+    public CompoundBlockComponentProvider(BlockComponentProvider primary) {
+        this.primary = primary;
+        this.secondary = new ArrayList<>();
+    }
+
+    public void addSecondary(BlockComponentProvider provider) {
+        secondary.add(provider);
+    }
+
+    @Override
+    public <T extends Component> boolean hasComponent(BlockView blockView, BlockPos pos, ComponentType<T> type, @Nullable Direction side) {
+        if (primary.hasComponent(blockView, pos, type, side)) return true;
+        for (BlockComponentProvider provider : secondary) {
+            if (provider.hasComponent(blockView, pos, type, side)) return true;
+        }
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public <T extends Component> T getComponent(BlockView blockView, BlockPos pos, ComponentType<T> type, @Nullable Direction side) {
+        T potential = primary.getComponent(blockView, pos, type, side);
+        if (potential != null) return potential;
+        for (BlockComponentProvider provider : secondary) {
+            potential = provider.getComponent(blockView, pos, type, side);
+            if (potential != null) return potential;
+        }
+        return null;
+    }
+
+    @Override
+    public Set<ComponentType<?>> getComponentTypes(BlockView blockView, BlockPos pos, @Nullable Direction side) {
+        Set<ComponentType<?>> ret = new HashSet<>(primary.getComponentTypes(blockView, pos, side));
+        for (BlockComponentProvider provider : secondary) {
+            ret.addAll(provider.getComponentTypes(blockView, pos, side));
+        }
+        return ret;
+    }
+}

--- a/cardinal-components-block/src/main/java/dev/onyxstudios/cca/internal/block/StaticBlockEntityComponentPlugin.java
+++ b/cardinal-components-block/src/main/java/dev/onyxstudios/cca/internal/block/StaticBlockEntityComponentPlugin.java
@@ -1,0 +1,143 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019-2020 OnyxStudios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package dev.onyxstudios.cca.internal.block;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import dev.onyxstudios.cca.api.component.v3.block.entity.BlockEntityComponentFactory;
+import dev.onyxstudios.cca.api.component.v3.block.entity.BlockEntityComponentFactoryRegistry;
+import dev.onyxstudios.cca.api.component.v3.block.entity.BlockEntityComponentInitializer;
+import dev.onyxstudios.cca.api.component.v3.event.BlockEntityComponentCallback;
+import dev.onyxstudios.cca.api.v3.component.ComponentContainer;
+import dev.onyxstudios.cca.api.v3.component.ComponentKey;
+import dev.onyxstudios.cca.internal.base.DynamicContainerFactory;
+import dev.onyxstudios.cca.internal.base.LazyDispatcher;
+import dev.onyxstudios.cca.internal.base.asm.StaticComponentLoadingException;
+import dev.onyxstudios.cca.internal.base.asm.StaticComponentPluginBase;
+import nerdhub.cardinal.components.api.component.Component;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.util.Identifier;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+public final class StaticBlockEntityComponentPlugin extends LazyDispatcher implements BlockEntityComponentFactoryRegistry {
+    public static final StaticBlockEntityComponentPlugin INSTANCE = new StaticBlockEntityComponentPlugin();
+
+    private StaticBlockEntityComponentPlugin() {
+        super("instantiating an entity");
+    }
+
+    private static String getSuffix(Class<?> entityClass) {
+        String simpleName = entityClass.getSimpleName();
+        return String.format("EntityImpl_%s_%s", simpleName, Integer.toHexString(entityClass.getName().hashCode()));
+    }
+
+    private final Map<Class<? extends BlockEntity>, Map</*ComponentType*/Identifier, BlockEntityComponentFactory<?, ?>>> componentFactories = new HashMap<>();
+    private final Map<Class<? extends BlockEntity>, Class<? extends ComponentContainer<?>>> containerClasses = new HashMap<>();
+    private final Map<Key, Class<? extends DynamicContainerFactory<?,?>>> factoryClasses = new HashMap<>();
+
+    public boolean requiresStaticFactory(Class<? extends BlockEntity> entityClass) {
+        this.ensureInitialized();
+        return entityClass == BlockEntity.class || this.componentFactories.containsKey(entityClass);
+    }
+
+    public Class<? extends DynamicContainerFactory<?,? extends Component>> spinDedicatedFactory(Key key) {
+        this.ensureInitialized();
+
+        // we need a cache as this method is called for a given class each time one of its subclasses is loaded.
+        return this.factoryClasses.computeIfAbsent(key, k -> {
+            Class<? extends BlockEntity> entityClass = k.blockEntityClass;
+
+            Map<Identifier, BlockEntityComponentFactory<?, ?>> compiled = new LinkedHashMap<>(this.componentFactories.getOrDefault(entityClass, Collections.emptyMap()));
+            Class<?> type = entityClass;
+
+            while (type != BlockEntity.class) {
+                type = type.getSuperclass();
+                this.componentFactories.getOrDefault(type, Collections.emptyMap()).forEach(compiled::putIfAbsent);
+            }
+
+            String implSuffix = getSuffix(entityClass);
+
+            try {
+                Class<? extends ComponentContainer<?>> containerCls = this.containerClasses.get(entityClass);
+                if (containerCls == null) {
+                    containerCls = StaticComponentPluginBase.spinComponentContainer(BlockEntityComponentFactory.class, Component.class, compiled, implSuffix);
+                    this.containerClasses.put(entityClass, containerCls);
+                }
+                return StaticComponentPluginBase.spinContainerFactory(implSuffix + "_" + k.eventCount, DynamicContainerFactory.class, containerCls, BlockEntityComponentCallback.class, k.eventCount, entityClass);
+            } catch (IOException e) {
+                throw new StaticComponentLoadingException("Failed to generate a dedicated component container for " + entityClass, e);
+            }
+        });
+    }
+
+    @Override
+    protected void init() {
+        StaticComponentPluginBase.processInitializers(
+            FabricLoader.getInstance().getEntrypointContainers("cardinal-components-entity", BlockEntityComponentInitializer.class),
+            initializer -> initializer.registerBlockEntityComponentFactories(this)
+        );
+    }
+
+    @Override
+    public <C extends Component, E extends BlockEntity> void registerFor(Class<E> target, ComponentKey<C> type, BlockEntityComponentFactory<C, E> factory) {
+        this.checkLoading(BlockEntityComponentFactoryRegistry.class, "register");
+        Map<Identifier, BlockEntityComponentFactory<?, ?>> specializedMap = this.componentFactories.computeIfAbsent(target, t -> new HashMap<>());
+        BlockEntityComponentFactory<?, ?> previousFactory = specializedMap.get(type.getId());
+        if (previousFactory != null) {
+            throw new StaticComponentLoadingException("Duplicate factory declarations for " + type.getId() + " on " + target + ": " + factory + " and " + previousFactory);
+        }
+        BlockEntityComponentFactory<Component, E> checked = entity -> Objects.requireNonNull(((BlockEntityComponentFactory<?, E>) factory).createForEntity(entity), "Component factory "+ factory + " for " + type.getId() + " returned null on " + entity.getClass().getSimpleName());
+        specializedMap.put(type.getId(), checked);
+    }
+
+    static class Key {
+        final int eventCount;
+        final Class<? extends BlockEntity> blockEntityClass;
+
+        public Key(int eventCount, Class<? extends BlockEntity> blockEntityClass) {
+            this.eventCount = eventCount;
+            this.blockEntityClass = blockEntityClass;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || this.getClass() != o.getClass()) return false;
+            Key key = (Key) o;
+            return this.eventCount == key.eventCount &&
+                this.blockEntityClass.equals(key.blockEntityClass);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.eventCount, this.blockEntityClass);
+        }
+    }
+}

--- a/cardinal-components-block/src/main/java/dev/onyxstudios/cca/mixin/block/common/MixinBlockEntity.java
+++ b/cardinal-components-block/src/main/java/dev/onyxstudios/cca/mixin/block/common/MixinBlockEntity.java
@@ -1,0 +1,66 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019-2020 OnyxStudios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package dev.onyxstudios.cca.mixin.block.common;
+
+import javax.annotation.Nonnull;
+
+import dev.onyxstudios.cca.api.v3.component.ComponentContainer;
+import dev.onyxstudios.cca.internal.base.InternalComponentProvider;
+import dev.onyxstudios.cca.internal.block.CardinalBlockInternals;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.nbt.CompoundTag;
+
+@Mixin(BlockEntity.class)
+public class MixinBlockEntity implements InternalComponentProvider {
+    @Unique
+    private ComponentContainer<?> components;
+
+    @Inject(method = "<init>*", at = @At("RETURN"))
+    private void initDataTracker(CallbackInfo ci) {
+        this.components = CardinalBlockInternals.createEntityComponentContainer((BlockEntity) (Object) this);
+    }
+
+    @Inject(method = "toTag", at = @At("RETURN"))
+    private void toTag(CompoundTag inputTag, CallbackInfoReturnable<CompoundTag> cir) {
+        this.components.toTag(cir.getReturnValue());
+    }
+
+    @Inject(method = "fromTag", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;readCustomDataFromTag(Lnet/minecraft/nbt/CompoundTag;)V", shift = At.Shift.AFTER))
+    private void fromTag(BlockState state, CompoundTag tag, CallbackInfo ci) {
+        this.components.fromTag(tag);
+    }
+
+    @Nonnull
+    @Override
+    public ComponentContainer<?> getComponentContainer() {
+        return components;
+    }
+}

--- a/cardinal-components-block/src/main/java/nerdhub/cardinal/components/api/component/BlockComponentProvider.java
+++ b/cardinal-components-block/src/main/java/nerdhub/cardinal/components/api/component/BlockComponentProvider.java
@@ -22,6 +22,7 @@
  */
 package nerdhub.cardinal.components.api.component;
 
+import dev.onyxstudios.cca.internal.block.CardinalBlockInternals;
 import nerdhub.cardinal.components.api.ComponentType;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -40,7 +41,17 @@ public interface BlockComponentProvider {
     }
 
     static BlockComponentProvider get(Block block) {
-        return (BlockComponentProvider) block;
+        return CardinalBlockInternals.getProvider(block);
+    }
+
+    /**
+     * Inject an additional provider onto a block,
+     * for the sake of adding compatibility for external blocks without using mixin.
+     * @param block The block to inject onto.
+     * @param provider The block component provider to inject.
+     */
+    static void addSecondaryProvider(Block block, BlockComponentProvider provider) {
+        CardinalBlockInternals.addSecondaryProvider(block, provider);
     }
 
     /**

--- a/cardinal-components-block/src/main/resources/fabric.mod.json
+++ b/cardinal-components-block/src/main/resources/fabric.mod.json
@@ -6,6 +6,11 @@
     "description": "dynamically exposing components",
     "version": "${version}",
     "side": "universal",
+    "entrypoints": {
+        "client": [
+            "dev.onyxstudios.cca.CardinalComponentsBlock::initClient"
+        ]
+    },
     "custom": {
         "modmenu:api": true,
         "modmenu:parent": "cardinal-components"

--- a/cardinal-components-block/src/main/resources/mixins.cardinal_components_block.json
+++ b/cardinal-components-block/src/main/resources/mixins.cardinal_components_block.json
@@ -4,7 +4,8 @@
     "compatibilityLevel": "JAVA_8",
     "package": "dev.onyxstudios.cca.mixin",
     "mixins": [
-        "block.common.MixinBlock"
+        "block.common.MixinBlock",
+        "block.common.MixinBlockEntity"
     ],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
(disclaimer: this PR was written before I realized that this was already in progress)

## The Problem
Almost all targets of Cardinal Components are **context-free**; they only require a single instance object to know enough about them to expose components. This is not the case with blocks or block entities, as blocks require a world, position, and access direction. Block entities provide their own world and position, but still require an access direction. This has resulted in the creation of `BlockComponentProvider`, an interface put on blocks or block entities to access components.

However, this removes the ability to inject components onto blocks not owned by your mod, without the use of mixin (which would cause incompatibilities if two mods want to inject onto the same block or BE). Furthermore, you must serialize, deserialize, and sync components manually, which makes the challenge of component injection even more difficult.

## The Solutions
I approached this problem by considering the two primary factors of components, storage and exposure, separately. I made block entities fully first-class component providers for storage, but kept block component providers in place for contextual exposure and access. 

Block Entities now have a `BlockEntityComponentCallback` plus support for static component initialization. These component containers are hooked into the `toTag` and `fromTag` methods of block entities, which must *always* be called to super for identifying information. I added `BlockEntitySyncedComponent` to support component syncing as well.

Beyond that, I added a system for adding additional components to a block component provider from externally. `BlockComponentProvider` now has a static method to add additional component providers onto a block. These are stored in a `CompoundBlockComponentProvider`, which is lazily created for only blocks who have additional injections. `BlockComponentProvider.get(Block)` now checks for compound providers, and returns them if necessary.

This should fix the two major issues in #40, and bring support for block components on par with all other component types in terms of extensibility.