### PR TITLE
Fix #108 by fixing the chunk format

### DIFF
--- a/cardinal-components-chunk/src/main/java/dev/onyxstudios/cca/mixin/chunk/common/MixinChunkSerializer.java
+++ b/cardinal-components-chunk/src/main/java/dev/onyxstudios/cca/mixin/chunk/common/MixinChunkSerializer.java
@@ -43,14 +43,12 @@ public abstract class MixinChunkSerializer {
     private static void deserialize(ServerWorld world, PointOfInterestStorage pointOfInterestStorage, ChunkPos chunkPos, NbtCompound tag, CallbackInfoReturnable<ProtoChunk> cir) {
         ProtoChunk ret = cir.getReturnValue();
         Chunk chunk = ret instanceof ReadOnlyChunk ? ((ReadOnlyChunk) ret).getWrappedChunk() : ret;
-        NbtCompound levelData = tag.getCompound("Level");
-        ((ComponentProvider)chunk).getComponentContainer().fromTag(levelData);
+        ((ComponentProvider)chunk).getComponentContainer().fromTag(tag);
     }
 
     @Inject(method = "serialize", at = @At("RETURN"))
     private static void serialize(ServerWorld world, Chunk chunk, CallbackInfoReturnable<NbtCompound> cir) {
         NbtCompound ret = cir.getReturnValue();
-        NbtCompound levelData = ret.getCompound("Level");
-        ((ComponentProvider)chunk).getComponentContainer().toTag(levelData);
+        ((ComponentProvider)chunk).getComponentContainer().toTag(ret);
     }
 }


### PR DESCRIPTION
In Minecraft 1.18 the chunk data is no longer stored in a separate "Level" tag.

Writing the tag has been tested using the Cardinal Components built in test mod. I have yet to test the reading of the chunk tag.