### PR TITLE
Use `client.world` instead of `client.player.world` for Immersive Portals compatibility

### DIFF
--- a/cardinal-components-entity/src/main/java/dev/onyxstudios/cca/internal/entity/CcaEntityClientNw.java
+++ b/cardinal-components-entity/src/main/java/dev/onyxstudios/cca/internal/entity/CcaEntityClientNw.java
@@ -47,7 +47,7 @@ public final class CcaEntityClientNw {
                     PacketByteBuf copy = new PacketByteBuf(buffer.copy());
                     client.execute(() -> {
                         try {
-                            componentType.maybeGet(Objects.requireNonNull(client.player).world.getEntityById(entityId))
+                            componentType.maybeGet(Objects.requireNonNull(client.world).getEntityById(entityId))
                                 .filter(c -> c instanceof AutoSyncedComponent)
                                 .ifPresent(c -> ((AutoSyncedComponent) c).applySyncPacket(copy));
                         } finally {


### PR DESCRIPTION
https://github.com/OnyxStudios/Cardinal-Components-API/issues/128

I haven't tested but it probably works because it's a small change.