### PR TITLE
Update to 1.21.10

### DIFF
--- a/cardinal-components-level/src/main/java/org/ladysnake/cca/mixin/level/common/MixinLevelProperties.java
+++ b/cardinal-components-level/src/main/java/org/ladysnake/cca/mixin/level/common/MixinLevelProperties.java
@@ -32,6 +32,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.storage.NbtWriteView;
 import net.minecraft.util.ErrorReporter;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.WorldProperties;
 import net.minecraft.world.gen.GeneratorOptions;
 import net.minecraft.world.level.LevelInfo;
 import net.minecraft.world.level.LevelProperties;
@@ -62,8 +63,8 @@ public abstract class MixinLevelProperties implements ServerWorldProperties, Com
     @Unique
     private ComponentContainer components;
 
-    @Inject(method = "<init>(Lnet/minecraft/nbt/NbtCompound;ZLnet/minecraft/util/math/BlockPos;FJJIIIZIZZZLjava/util/Optional;IILjava/util/UUID;Ljava/util/Set;Ljava/util/Set;Lnet/minecraft/world/timer/Timer;Lnet/minecraft/nbt/NbtCompound;Lnet/minecraft/entity/boss/dragon/EnderDragonFight$Data;Lnet/minecraft/world/level/LevelInfo;Lnet/minecraft/world/gen/GeneratorOptions;Lnet/minecraft/world/level/LevelProperties$SpecialProperty;Lcom/mojang/serialization/Lifecycle;)V", at = @At("RETURN"))
-    private void initComponents(NbtCompound playerData, boolean modded, BlockPos spawnPos, float spawnAngle, long time, long timeOfDay, int version, int clearWeatherTime, int rainTime, boolean raining, int thunderTime, boolean thundering, boolean initialized, boolean difficultyLocked, Optional worldBorder, int wanderingTraderSpawnDelay, int wanderingTraderSpawnChance, UUID wanderingTraderId, Set serverBrands, Set removedFeatures, Timer scheduledEvents, NbtCompound customBossEvents, EnderDragonFight.Data dragonFight, LevelInfo levelInfo, GeneratorOptions generatorOptions, LevelProperties.SpecialProperty specialProperty, Lifecycle lifecycle, CallbackInfo ci)  {
+    @Inject(method = "<init>(Lnet/minecraft/nbt/NbtCompound;ZLnet/minecraft/world/WorldProperties$SpawnPoint;JJIIIZIZZZLjava/util/Optional;IILjava/util/UUID;Ljava/util/Set;Ljava/util/Set;Lnet/minecraft/world/timer/Timer;Lnet/minecraft/nbt/NbtCompound;Lnet/minecraft/entity/boss/dragon/EnderDragonFight$Data;Lnet/minecraft/world/level/LevelInfo;Lnet/minecraft/world/gen/GeneratorOptions;Lnet/minecraft/world/level/LevelProperties$SpecialProperty;Lcom/mojang/serialization/Lifecycle;)V", at = @At("RETURN"))
+    private void initComponents(NbtCompound playerData, boolean modded, SpawnPoint spawnPoint, long time, long timeOfDay, int version, int clearWeatherTime, int rainTime, boolean raining, int thunderTime, boolean thundering, boolean initialized, boolean difficultyLocked, Optional worldBorder, int wanderingTraderSpawnDelay, int wanderingTraderSpawnChance, UUID wanderingTraderId, Set serverBrands, Set removedFeatures, Timer scheduledEvents, NbtCompound customBossEvents, EnderDragonFight.Data dragonFight, LevelInfo levelInfo, GeneratorOptions generatorOptions, LevelProperties.SpecialProperty specialProperty, Lifecycle lifecycle, CallbackInfo ci)  {
         this.components = StaticLevelComponentPlugin.createContainer(this);
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ org.gradle.parallel=true
 fabric.loom.multiProjectOptimisation=true
 
 #see https://fabricmc.net/develop/
-minecraft_version=25w36b
-yarn_mappings=16
+minecraft_version=1.21.10
+yarn_mappings=2
 loader_version=0.17.2
 #Fabric api
-fabric_api_version=0.133.1+1.21.9
+fabric_api_version=0.135.0+1.21.10
 
 elmendorf_version=0.16.0
 
@@ -18,8 +18,8 @@ immersive_portals_version=v6.0.3-mc1.21.1
 mod_version = 7.1.0-beta.1
 curseforge_id = 318449
 modrinth_id = K01OU20C
-curseforge_versions = 1.21.9-snapshot
-modrinth_versions = 25w36b
+curseforge_versions = 1.21.10
+modrinth_versions = 1.21.10
 release_type = beta
 display_name = Cardinal-Components-API
 owners = Ladysnake


### PR DESCRIPTION
Small updates for 1.21.10. There was a small change to the `LevelProperties` class that caused a mixin from this mod to break on 1.21.10, despite it being a hotfix version :(

Game tests all pass on my end, and it seems to work just fine with a mod of mine that uses CCA. 