### PR TITLE
[26.1] Add launchpad support

### DIFF
--- a/cardinal-components-base/src/main/resources/fabric.mod.json
+++ b/cardinal-components-base/src/main/resources/fabric.mod.json
@@ -13,13 +13,6 @@
   },
   "custom": {
     "launchpad:compatible": true,
-    "launchpad:overrides": {
-      "id": "cardinal_components_base",
-      "depends": {
-        "minecraft": ">=26.1-",
-        "fabric_api_base": ">=0.1.2"
-      }
-    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-base/src/main/resources/fabric.mod.json
+++ b/cardinal-components-base/src/main/resources/fabric.mod.json
@@ -12,6 +12,14 @@
     ]
   },
   "custom": {
+    "launchpad:compatible": true,
+    "launchpad:overrides": {
+      "id": "cardinal_components_base",
+      "depends": {
+        "minecraft": ">=26.1-",
+        "fabric_api_base": ">=0.1.2"
+      }
+    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-block/src/main/resources/fabric.mod.json
+++ b/cardinal-components-block/src/main/resources/fabric.mod.json
@@ -16,16 +16,6 @@
   },
   "custom": {
     "launchpad:compatible": true,
-    "launchpad:overrides": {
-      "id": "cardinal_components_block",
-      "depends": {
-        "minecraft": ">=26.1-",
-        "fabric_api_base": "*",
-        "fabric_api_lookup_api_v1": "*",
-        "fabric_networking_api_v1": "*",
-        "cardinal_components_base": ">=8.0.0-alpha.1"
-      }
-    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-block/src/main/resources/fabric.mod.json
+++ b/cardinal-components-block/src/main/resources/fabric.mod.json
@@ -15,6 +15,17 @@
     ]
   },
   "custom": {
+    "launchpad:compatible": true,
+    "launchpad:overrides": {
+      "id": "cardinal_components_block",
+      "depends": {
+        "minecraft": ">=26.1-",
+        "fabric_api_base": "*",
+        "fabric_api_lookup_api_v1": "*",
+        "fabric_networking_api_v1": "*",
+        "cardinal_components_base": ">=8.0.0-alpha.1"
+      }
+    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-chunk/src/main/resources/fabric.mod.json
+++ b/cardinal-components-chunk/src/main/resources/fabric.mod.json
@@ -15,6 +15,16 @@
     ]
   },
   "custom": {
+    "launchpad:compatible": true,
+    "launchpad:overrides": {
+      "id": "cardinal_components_chunk",
+      "depends": {
+        "minecraft": ">=26.1-",
+        "fabric_api_base": "*",
+        "cardinal_components_base": ">=8.0.0-alpha.1",
+        "fabric_networking_api_v1": "*"
+      }
+    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-chunk/src/main/resources/fabric.mod.json
+++ b/cardinal-components-chunk/src/main/resources/fabric.mod.json
@@ -16,15 +16,6 @@
   },
   "custom": {
     "launchpad:compatible": true,
-    "launchpad:overrides": {
-      "id": "cardinal_components_chunk",
-      "depends": {
-        "minecraft": ">=26.1-",
-        "fabric_api_base": "*",
-        "cardinal_components_base": ">=8.0.0-alpha.1",
-        "fabric_networking_api_v1": "*"
-      }
-    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-entity/src/main/resources/fabric.mod.json
+++ b/cardinal-components-entity/src/main/resources/fabric.mod.json
@@ -16,14 +16,6 @@
   },
   "custom": {
     "launchpad:compatible": true,
-    "launchpad:overrides": {
-      "id": "cardinal_components_entity",
-      "depends": {
-        "minecraft": ">=26.1-",
-        "fabric_api_base": "*",
-        "cardinal_components_base": ">=8.0.0-alpha.1"
-      }
-    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-entity/src/main/resources/fabric.mod.json
+++ b/cardinal-components-entity/src/main/resources/fabric.mod.json
@@ -15,6 +15,15 @@
     ]
   },
   "custom": {
+    "launchpad:compatible": true,
+    "launchpad:overrides": {
+      "id": "cardinal_components_entity",
+      "depends": {
+        "minecraft": ">=26.1-",
+        "fabric_api_base": "*",
+        "cardinal_components_base": ">=8.0.0-alpha.1"
+      }
+    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-item/src/main/resources/fabric.mod.json
+++ b/cardinal-components-item/src/main/resources/fabric.mod.json
@@ -7,6 +7,15 @@
   "icon": "assets/cardinal-components-item/icon.png",
   "version": "${version}",
   "custom": {
+    "launchpad:compatible": true,
+    "launchpad:overrides": {
+      "id": "cardinal_components_item",
+      "depends": {
+        "minecraft": ">=1.17-",
+        "fabric_api_base": "*",
+        "cardinal_components_base": "*"
+      }
+    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-item/src/main/resources/fabric.mod.json
+++ b/cardinal-components-item/src/main/resources/fabric.mod.json
@@ -8,14 +8,6 @@
   "version": "${version}",
   "custom": {
     "launchpad:compatible": true,
-    "launchpad:overrides": {
-      "id": "cardinal_components_item",
-      "depends": {
-        "minecraft": ">=1.17-",
-        "fabric_api_base": "*",
-        "cardinal_components_base": "*"
-      }
-    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-level/src/main/resources/fabric.mod.json
+++ b/cardinal-components-level/src/main/resources/fabric.mod.json
@@ -16,15 +16,6 @@
   },
   "custom": {
     "launchpad:compatible": true,
-    "launchpad:overrides": {
-      "id": "cardinal_components_level",
-      "depends": {
-        "minecraft": ">=26.1-",
-        "fabric_api_base": "*",
-        "cardinal_components_base": ">=8.0.0-alpha.1",
-        "fabric_networking_api_v1": "*"
-      }
-    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-level/src/main/resources/fabric.mod.json
+++ b/cardinal-components-level/src/main/resources/fabric.mod.json
@@ -15,6 +15,16 @@
     ]
   },
   "custom": {
+    "launchpad:compatible": true,
+    "launchpad:overrides": {
+      "id": "cardinal_components_level",
+      "depends": {
+        "minecraft": ">=26.1-",
+        "fabric_api_base": "*",
+        "cardinal_components_base": ">=8.0.0-alpha.1",
+        "fabric_networking_api_v1": "*"
+      }
+    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-leveldata/src/main/resources/fabric.mod.json
+++ b/cardinal-components-leveldata/src/main/resources/fabric.mod.json
@@ -15,6 +15,16 @@
     ]
   },
   "custom": {
+    "launchpad:compatible": true,
+    "launchpad:overrides": {
+      "id": "cardinal_components_leveldata",
+      "depends": {
+        "minecraft": ">=26.1-",
+        "fabric_api_base": "*",
+        "cardinal_components_base": ">=8.0.0-alpha.1",
+        "fabric_networking_api_v1": "*"
+      }
+    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-leveldata/src/main/resources/fabric.mod.json
+++ b/cardinal-components-leveldata/src/main/resources/fabric.mod.json
@@ -16,15 +16,6 @@
   },
   "custom": {
     "launchpad:compatible": true,
-    "launchpad:overrides": {
-      "id": "cardinal_components_leveldata",
-      "depends": {
-        "minecraft": ">=26.1-",
-        "fabric_api_base": "*",
-        "cardinal_components_base": ">=8.0.0-alpha.1",
-        "fabric_networking_api_v1": "*"
-      }
-    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-scoreboard/src/main/resources/fabric.mod.json
+++ b/cardinal-components-scoreboard/src/main/resources/fabric.mod.json
@@ -16,14 +16,6 @@
   },
   "custom": {
     "launchpad:compatible": true,
-    "launchpad:overrides": {
-      "id": "cardinal_components_scoreboard",
-      "depends": {
-        "minecraft": ">=26.1-",
-        "fabric_api_base": "*",
-        "cardinal_components_base": ">=8.0.0-alpha.1"
-      }
-    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/cardinal-components-scoreboard/src/main/resources/fabric.mod.json
+++ b/cardinal-components-scoreboard/src/main/resources/fabric.mod.json
@@ -15,6 +15,15 @@
     ]
   },
   "custom": {
+    "launchpad:compatible": true,
+    "launchpad:overrides": {
+      "id": "cardinal_components_scoreboard",
+      "depends": {
+        "minecraft": ">=26.1-",
+        "fabric_api_base": "*",
+        "cardinal_components_base": ">=8.0.0-alpha.1"
+      }
+    },
     "modmenu": {
       "badges": [ "library" ],
       "parent": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,6 +7,10 @@
     "version": "${version}",
     "icon": "assets/cardinal-components/icon.png",
     "custom": {
+      "launchpad:compatible": true,
+      "launchpad:overrides": {
+        "id": "cardinal_components"
+      },
       "modmenu": {
         "badges": ["library"]
       }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,9 +8,6 @@
     "icon": "assets/cardinal-components/icon.png",
     "custom": {
       "launchpad:compatible": true,
-      "launchpad:overrides": {
-        "id": "cardinal_components"
-      },
       "modmenu": {
         "badges": ["library"]
       }


### PR DESCRIPTION
Title says all, adds support for Launchpad for real fake Neoforge support. Only has minor additions to each module's fabric.mod.json